### PR TITLE
Show arena display name in ArenasMenu icon and ChooseArenaMenu

### DIFF
--- a/src/main/java/rip/diamond/practice/arenas/menu/ArenasMenu.java
+++ b/src/main/java/rip/diamond/practice/arenas/menu/ArenasMenu.java
@@ -28,7 +28,7 @@ public class ArenasMenu extends PaginatedMenu {
                 @Override
                 public ItemStack getButtonItem(Player player) {
                     return new ItemBuilder(arena.getIcon())
-                            .name(Language.ARENA_MENU_ARENA_EDIT_NAME.toString(arena.getName()))
+                            .name(Language.ARENA_MENU_ARENA_EDIT_NAME.toString(arena.getDisplayName(), arena.getName()))
                             .lore(Language.ARENA_MENU_ARENA_EDIT_LORE.toStringList())
                             .build();
                 }

--- a/src/main/java/rip/diamond/practice/duel/menu/ChooseArenaMenu.java
+++ b/src/main/java/rip/diamond/practice/duel/menu/ChooseArenaMenu.java
@@ -40,7 +40,7 @@ public class ChooseArenaMenu extends PaginatedMenu {
                     @Override
                     public ItemStack getButtonItem(Player player) {
                         return new ItemBuilder(arena.getIcon().clone())
-                                .name(Language.DUEL_CHOOSE_ARENA_MENU_BUTTON_NAME.toString(arena.getName()))
+                                .name(Language.DUEL_CHOOSE_ARENA_MENU_BUTTON_NAME.toString(arena.getDisplayName()))
                                 .lore(Language.DUEL_CHOOSE_ARENA_MENU_BUTTON_LORE.toStringList())
                                 .build();
                     }

--- a/src/main/resources/language-tw.yml
+++ b/src/main/resources/language-tw.yml
@@ -335,7 +335,7 @@ arena:
   menu:
     title: "場地一覽"
     arena-edit:
-      name: "&b&l{0}"
+      name: "&b&l{0} &7({1})"
       lore:
         - ""
         - "&e&n點擊進行場地設置!"

--- a/src/main/resources/language.yml
+++ b/src/main/resources/language.yml
@@ -277,7 +277,7 @@ arena:
   menu:
     title: "Arenas Preview"
     arena-edit:
-      name: "&b&l{0}"
+      name: "&b&l{0} &7({1})"
       lore:
         - ""
         - "&e&nClick to edit arena settings!"


### PR DESCRIPTION
This PR adds a few things that were missing from #101.
- Show the arena display name in the ArenasMenu icon and ChooseArenaMenu.