### PR TITLE
feat: MatchRoundStartEvent & MatchRoundEndEvent

### DIFF
--- a/src/main/java/rip/diamond/practice/event/MatchRoundEndEvent.java
+++ b/src/main/java/rip/diamond/practice/event/MatchRoundEndEvent.java
@@ -1,0 +1,16 @@
+package rip.diamond.practice.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import rip.diamond.practice.match.Match;
+import rip.diamond.practice.util.BaseEvent;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class MatchRoundEndEvent extends BaseEvent {
+
+    private final Match match;
+    
+}

--- a/src/main/java/rip/diamond/practice/event/MatchRoundStartEvent.java
+++ b/src/main/java/rip/diamond/practice/event/MatchRoundStartEvent.java
@@ -1,0 +1,16 @@
+package rip.diamond.practice.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import rip.diamond.practice.match.Match;
+import rip.diamond.practice.util.BaseEvent;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class MatchRoundStartEvent extends BaseEvent {
+
+    private final Match match;
+    
+}

--- a/src/main/java/rip/diamond/practice/match/task/MatchNewRoundTask.java
+++ b/src/main/java/rip/diamond/practice/match/task/MatchNewRoundTask.java
@@ -6,6 +6,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import rip.diamond.practice.Eden;
 import rip.diamond.practice.Language;
+import rip.diamond.practice.event.MatchRoundEndEvent;
+import rip.diamond.practice.event.MatchRoundStartEvent;
 import rip.diamond.practice.match.Match;
 import rip.diamond.practice.match.MatchState;
 import rip.diamond.practice.match.MatchTaskTicker;
@@ -42,6 +44,10 @@ public class MatchNewRoundTask extends MatchTaskTicker {
             match.broadcastSubTitle("");
             match.setState(MatchState.FIGHTING);
             match.broadcastSound(Sound.FIREWORK_BLAST);
+
+            MatchRoundStartEvent event = new MatchRoundStartEvent(match);
+            event.call();
+
             cancel();
             return;
         }
@@ -96,6 +102,9 @@ public class MatchNewRoundTask extends MatchTaskTicker {
                 //Cancel any runnable which affects the gameplay
                 match.getTasks().stream().filter(taskTicker -> taskTicker instanceof MatchClearBlockTask).forEach(BukkitRunnable::cancel);
             }
+
+            MatchRoundEndEvent event = new MatchRoundEndEvent(match);
+            event.call();
         }
     }
 


### PR DESCRIPTION
This PR adds MatchRoundStartEvent & MatchRoundEndEvent

The reason for this is that you can do something after the round starts and after the round ends.
In my case, I use this to remove a region of block in the match arena after the round starts and restore it back after the round ends.