### PR TITLE
fix: persist papi expansion when placeholder reloads

### DIFF
--- a/src/main/java/rip/diamond/practice/hook/plugin/placeholderapi/EdenPlaceholderExpansion.java
+++ b/src/main/java/rip/diamond/practice/hook/plugin/placeholderapi/EdenPlaceholderExpansion.java
@@ -27,6 +27,11 @@ public class EdenPlaceholderExpansion extends PlaceholderExpansion {
     }
 
     @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
     public String getVersion() {
         return Eden.INSTANCE.getDescription().getVersion();
     }


### PR DESCRIPTION
This PR make Eden's PlaceholderAPI expansion persist when placeholder reloads.