### PR TITLE
Send an empty title at match start to stop showing the countdown

### DIFF
--- a/src/main/java/rip/diamond/practice/match/task/MatchNewRoundTask.java
+++ b/src/main/java/rip/diamond/practice/match/task/MatchNewRoundTask.java
@@ -40,7 +40,7 @@ public class MatchNewRoundTask extends MatchTaskTicker {
 
         if (getTicks() == 0) {
             match.broadcastMessage(Language.MATCH_NEW_ROUND_START_MESSAGE.toString());
-            match.broadcastSubTitle("");
+            match.broadcastTitle("");
             match.setState(MatchState.FIGHTING);
             match.broadcastSound(Sound.FIREWORK_BLAST);
 


### PR DESCRIPTION
When the match starts, the countdown title remains for a little longer. Sending an empty title would be cleaner